### PR TITLE
img alt tags for accessibility

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -16,8 +16,8 @@ if (process.env.JAWSDB_URL) {
         host: "localhost",
         user: "root",
         // password: "root",
-        // password: "]myz_y:92^s3q", // cory local
-        password: "root", // josh local
+        password: "]myz_y:92^s3q", // cory local
+        // password: "root", // josh local
         database: "accounts_db"
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,35 @@
             "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
             "dev": true
         },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+                    "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+                }
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -589,6 +618,11 @@
             "requires": {
                 "ee-first": "1.1.1"
             }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "compression": "^1.7.4",
         "express": "^4.16.3",
         "express-handlebars": "^3.0.0",
         "mysql": "^2.16.0"

--- a/server.js
+++ b/server.js
@@ -1,8 +1,19 @@
 var express = require("express");
 
 var PORT = process.env.PORT || 8080;
-
 var app = express();
+var compression = require('compression')
+app.use(compression({ filter: shouldCompress }))
+ 
+function shouldCompress (req, res) {
+  if (req.headers['x-no-compression']) {
+    // don't compress responses with this request header
+    return false
+  }
+ 
+  // fallback to standard filter function
+  return compression.filter(req, res)
+}
 
 // Serve static content for the app from the "public" directory in the application directory.
 app.use(express.static("public"));

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -1,7 +1,7 @@
 <div class="columns" id="home">
     <div class="column is-one-quarter">
         <div class="column is-full cardStyle center">
-            <img src="/assets/img/croc.png">
+            <img src="/assets/img/croc.png" alt="croc logo">
             <br><a id="addAccountLink">Add Account</a> | <a href="/">Log Out</a>
         </div>
         {{#each accounts}}

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -1,7 +1,7 @@
 <div id="indexContainer">
     <div class="columns" id="index">
         <div class="column">
-            <img src="/assets/img/croc.png"><br>
+            <img src="/assets/img/croc.png" alt="croc logo"><br>
             <sectiion id="companyName">CREDIT CROC</sectiion>
             <section id="companySlogan">Take a bite out of debt!</section>
             <section id="about">Managing your debt is lame. Credit Croc is cool. Credit Croc keeps track of your debt so you don't have to!</section>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -10,6 +10,8 @@
 	<script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
 <body>
-	{{{ body }}}
+	<div role="img" aria-label="background image">
+		{{{ body }}}
+	</div>
 </body>
 </html>


### PR DESCRIPTION
added alt "croc logo" to the img logo, and added aria-label="background image" to main.handlebars which acts as an alt where we do not have an <img> tag directly in the code for the background image (it's sourced in the CSS.).

this improves code to meet accessibility standards.